### PR TITLE
Adds TerminalFactorySpi, and (incomplete) ResponseAPDU implementation.

### DIFF
--- a/framework/src/main/java/javax/smartcardio/CommandAPDU.java
+++ b/framework/src/main/java/javax/smartcardio/CommandAPDU.java
@@ -19,6 +19,8 @@ public class CommandAPDU {
      * @param apduLength
      */
     public CommandAPDU(byte[] apdu, int apduOffset, int apduLength) {
+        mBytes = Arrays.copyOfRange(apdu, apduOffset, apduLength);
+        mNc = apduLength;
     }
 
     /**

--- a/framework/src/main/java/javax/smartcardio/ResponseAPDU.java
+++ b/framework/src/main/java/javax/smartcardio/ResponseAPDU.java
@@ -6,7 +6,7 @@ public class ResponseAPDU {
     private byte[] mBytes;
 
     public ResponseAPDU(byte[] apdu) {
-        this.mBytes = apdu;
+        this.mBytes = apdu.clone();
     }
 
     public byte[] getBytes() {

--- a/framework/src/main/java/javax/smartcardio/ResponseAPDU.java
+++ b/framework/src/main/java/javax/smartcardio/ResponseAPDU.java
@@ -1,4 +1,34 @@
 package javax.smartcardio;
 
+import java.util.Arrays;
+
 public class ResponseAPDU {
+    private byte[] mBytes;
+
+    public ResponseAPDU(byte[] apdu) {
+        this.mBytes = apdu;
+    }
+
+    public byte[] getBytes() {
+        return this.mBytes;
+    }
+
+    public String toString() {
+        return "ResponseAPDU: " + mBytes.length + " bytes";
+    }
+
+    public int hashCode() {
+        return Arrays.hashCode(mBytes);
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ResponseAPDU)) {
+            return false;
+        }
+        ResponseAPDU other = (ResponseAPDU) obj;
+        return Arrays.equals(mBytes, other.getBytes());
+    }
 }

--- a/framework/src/main/java/javax/smartcardio/TerminalFactorySpi.java
+++ b/framework/src/main/java/javax/smartcardio/TerminalFactorySpi.java
@@ -1,0 +1,6 @@
+package javax.smartcardio;
+
+public abstract class TerminalFactorySpi {
+    protected TerminalFactorySpi() { }
+    protected abstract CardTerminals engineTerminals();
+}


### PR DESCRIPTION
- Provide stub `TerminalFactorySpi` implementation
- Adds incomplete `ResponseAPDU` implementation
- Adds `CommandAPDU(bytes[], int, int)` implementation

This seems to be good enough to let [jnasmartcardio](https://github.com/jnasmartcardio/jnasmartcardio) work, grabbing a list of terminals directly with `Smartcardio.JnaTerminalFactorySpi(new Object()).engineTerminals().list()`.

This let me successfully communicate with contactless DESFire, FeliCa and JCOP cards using an ACS ACR122U reader, and contact JCOP cards cards using a ACR38 reader.